### PR TITLE
API standardization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.2.0 [April 27, 2016]
+* Modify API for most existing function to match other agents
+* Make most Instrumental calls return the value being sent, or the action result for Time()
+* Improve behavior on disconnect/reconnect
+
 ### 0.1.0 [April 13, 2016]
 * Clean up existing build process
 

--- a/Instrumental.nuspec
+++ b/Instrumental.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Instrumental</id>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <authors>Nathan Acuff</authors>
     <owners>Nathan Acuff</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>

--- a/src/Agent.cs
+++ b/src/Agent.cs
@@ -115,7 +115,7 @@ namespace Instrumental
           if (!ValidateNote(message)) return null;
           if (!Enabled) return message;
           int metricTime = (time ?? DateTime.Now).ToEpoch();
-          _collector.SendMessage(String.Format("notice {0} {1} {2}", metricTime, duration?.Seconds ?? 0, message));
+          _collector.SendMessage(String.Format("notice {0} {1} {2}", metricTime, duration?.TotalSeconds ?? 0, message));
           return message;
         }
       catch (Exception e)

--- a/src/Agent.cs
+++ b/src/Agent.cs
@@ -48,6 +48,7 @@ namespace Instrumental
                                   );
     }
 
+    // should return value if the arguments were valid, null otherwise
     public void Gauge(String metricName, float value, DateTime? time = null, int count = 1)
     {
       try
@@ -62,6 +63,9 @@ namespace Instrumental
         }
     }
 
+    // can we make this return the original value?
+    // change this to private
+    // write a public version that does not take durationMultiplier
     public void Time(String metricName, Action action, float durationMultiplier = 1)
     {
       var start = DateTime.Now;
@@ -77,16 +81,18 @@ namespace Instrumental
         }
     }
 
+    // signature should match time
     public void TimeMs(String metricName, Action action)
     {
       Time(metricName, action, 1000);
     }
 
+    // should return value if the arguments were valid, null otherwise
     public void Increment(String metricName, float value = 1, DateTime? time = null, int count = 1)
-    {
-      try
-        {
-          if (!Enabled || !ValidateMetricName(metricName)) return;
+      {
+          try
+          {
+              if (!Enabled || !ValidateMetricName(metricName)) return;
           int metricTime = (time ?? DateTime.Now).ToEpoch();
           _collector.SendMessage(String.Format("increment {0} {1} {2} {3}", metricName, value, metricTime, count));
         }
@@ -96,7 +102,8 @@ namespace Instrumental
         }
     }
 
-    public void Notice(String message, float durationInSeconds = 0, DateTime? time = null)
+    // should return the message, if it was valid
+    public void Notice(String message, DateTime? time = null, float durationInSeconds = 0)
     {
       try
         {

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0")]
-[assembly: AssemblyFileVersion("0.1.0")]
+[assembly: AssemblyVersion("0.2.0")]
+[assembly: AssemblyFileVersion("0.2.0")]

--- a/test/AgentTest.cs
+++ b/test/AgentTest.cs
@@ -77,7 +77,7 @@ namespace Instrumental
     [Test]
     public void TestNoticeAtATime()
     {
-      agent.Notice("C# test notice FROM THE PAST please ignore.", 300, pastEventTime);
+      agent.Notice("C# test notice FROM THE PAST please ignore.", pastEventTime, 300);
     }
 
     [Test]

--- a/test/AgentTest.cs
+++ b/test/AgentTest.cs
@@ -24,7 +24,7 @@ namespace Instrumental
       agent = new Agent(testKey);
     }
 
-    [TestFixtureTearDown]
+    [OneTimeTearDown]
     public void FixtureTearDown()
     {
       // so that all the background workers finish
@@ -138,7 +138,7 @@ TestIncrementPast", 13, pastEventTime));
     {
       bool excepted = false;
       try { agent = new Agent(null); }
-      catch(ArgumentException e) { excepted = true; }
+      catch(ArgumentException) { excepted = true; }
       Assert.AreEqual(true, excepted);
     }
 

--- a/test/AgentTest.cs
+++ b/test/AgentTest.cs
@@ -47,19 +47,32 @@ namespace Instrumental
     [Test]
     public void TestTime()
     {
-      agent.Time("csharp.TestTime", () => { System.Threading.Thread.Sleep(100); });
+      agent.Time("csharp.TestTime", () => { System.Threading.Thread.Sleep(100); return 1; });
+    }
+
+    [Test]
+    public void TimeReturnsActionResult()
+    {
+      var actionResult = 27;
+      Func<int> action = () => { return actionResult; };
+      Assert.AreEqual(actionResult, agent.Time("csharp.TestReturns", action));
+      var actionResult2 = "things";
+      Func<string> action2 = () => { return actionResult2; };
+      Assert.AreEqual(actionResult2, agent.Time("csharp.TestReturns", action2));
+      Assert.AreEqual(actionResult2, agent.Time("csharp.TestReturns", () => { return actionResult2; }));;
     }
 
     [Test]
     public void TestTimeMs()
     {
-      agent.TimeMs("csharp.TestTimeMs", () => { System.Threading.Thread.Sleep(100); });
+      agent.TimeMs("csharp.TestTimeMs", () => { System.Threading.Thread.Sleep(100); return 1; });
     }
 
     [Test]
     public void TestNotice()
     {
-      agent.Notice("C# test notice please ignore.");
+        var message = "C# test notice please ignore.";
+        Assert.AreEqual(message, agent.Notice(message));
     }
 
     [Test]
@@ -71,13 +84,27 @@ namespace Instrumental
     [Test]
     public void TestIncrementAtATime()
     {
-      agent.Increment("csharp.TestIncrementPast", 13, pastEventTime);
+      Assert.AreEqual(13, agent.Increment("csharp.TestIncrementPast", 13, pastEventTime));
+    }
+
+    [Test]
+    public void DisabledIncrementReturnsValue()
+    {
+      agent.Enabled = false;
+      Assert.AreEqual(13, agent.Increment("csharp.TestIncrementPast", 13, pastEventTime));
+    }
+
+    [Test]
+    public void InvalidMetricNameReturnsNull()
+    {
+      Assert.AreEqual(null, agent.Increment(@"csharp.
+TestIncrementPast", 13, pastEventTime));
     }
 
     [Test]
     public void TestNoticeAtATime()
     {
-      agent.Notice("C# test notice FROM THE PAST please ignore.", pastEventTime, 300);
+      agent.Notice("C# test notice FROM THE PAST using TimeSpan", pastEventTime, TimeSpan.FromMinutes(3));
     }
 
     [Test]


### PR DESCRIPTION
Make the Api of this agent as much like the ruby agent as possible:
- Same arguments in the same order
- Gauge, Increment, and Notice return the given value if everything is okay, null otherwise
- Time takes a Func<T> rather than an Action, and returns the resultant T.
