### PR TITLE
In tests, use TestFixtureTearDown to wait for the collector thread to finish

### DIFF
--- a/test/AgentTest.cs
+++ b/test/AgentTest.cs
@@ -24,7 +24,9 @@ namespace Instrumental
       agent = new Agent(testKey);
     }
 
-    [OneTimeTearDown]
+    // Despite the compiler warning, you cannot use OneTimeTearDown here, it will not fire
+    // Thanks, NUnit.
+    [TestFixtureTearDown]
     public void FixtureTearDown()
     {
       // so that all the background workers finish


### PR DESCRIPTION
Despite compiler warnings, OneTimeTearDown does not appear to work, but good ol TestFixtureTearDown overcomes deprecation to deliver quality results.
