### PR TITLE
Standardize the agent string a little better.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### UNRELEASED
+* make agent string easier to digest for Instrumental
+
 ### 1.0.0 [May 9, 2016]
 * Improvements in authentication mechanism
 * Time() can now be used with Actions (which return void)

--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ bg.RunWorkerAsync();
 Links
 =====
 
-[Instrumental](http://instrumentalapp.com)
-[Common.logging](http://netcommon.sourceforge.net/)
+- [Instrumental](http://instrumentalapp.com)
+- [Common.logging](http://netcommon.sourceforge.net/)

--- a/src/Collector.cs
+++ b/src/Collector.cs
@@ -136,7 +136,7 @@ namespace Instrumental
 
     private void Authenticate(Socket socket)
     {
-      var helloString = $"hello version dotnet/{Agent.AgentVersion}\n";
+      var helloString = $"hello version dotnet/instrumental_agent/{Agent.AgentVersion}\n";
       var authenticateString = $"authenticate {_apiKey}\n";
 
       var data = System.Text.Encoding.ASCII.GetBytes(helloString + authenticateString);


### PR DESCRIPTION
Make the dotnet hello handshake include the agent string in the manner of the other 1st party agents.

Fixes #16 
