### PR TITLE
Use higher precision timers for Time and TimeMs

### DIFF
--- a/src/Agent.cs
+++ b/src/Agent.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Text.RegularExpressions;
 using Common.Logging;
+using System.Diagnostics;
 
 namespace Instrumental
 {
@@ -134,30 +135,32 @@ namespace Instrumental
 
     private T ActuallyTime<T>(String metricName, Func<T> action, double durationMultiplier = 1)
     {
-      var start = DateTime.Now;
+      var timer = new Stopwatch();
+      timer.Start();
       try
         {
           return action();
         }
       finally
         {
-          var end = DateTime.Now;
-          var duration = end - start;
+          timer.Stop();
+          var duration = timer.Elapsed;
           Gauge(metricName, duration.TotalSeconds * durationMultiplier);
         }
     }
 
     private void ActuallyTime(String metricName, Action action, double durationMultiplier = 1)
     {
-      var start = DateTime.Now;
+      var timer = new Stopwatch();
       try
         {
           action();
         }
       finally
         {
-          var end = DateTime.Now;
-          var duration = end - start;
+
+          timer.Stop();
+          var duration = timer.Elapsed;
           Gauge(metricName, duration.TotalSeconds * durationMultiplier);
         }
     }


### PR DESCRIPTION
Uses System.Diagnostics.Stopwatch instead of DateTime.Now.  Fixes #19.

TLDR summary: DateTime.now is highly precise (sub-millisecond) but not very accurate (subtracting two DateTimes is a bad way to do performance timing).  Stopwatch is less precise, but much more accurate.  It may still be off in some situations, but this is vastly better, and improving from here requires using more exotic counters and/or messing with affinities and priorities - things we should not do in this agent.
