### PR TITLE
Reject unicode metric names

### DIFF
--- a/src/Agent.cs
+++ b/src/Agent.cs
@@ -62,7 +62,8 @@ namespace Instrumental
       _collector = new Collector(apiKey);
 
       var validationOptions = RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.ExplicitCapture;
-      _validateMetric = new Regex(@"^([\d\w\-_]+\.)*[\d\w\-_]+$", validationOptions);
+      _validateMetric = new Regex(@"^([a-zA-Z0-9\-_]+\.)*[a-zA-Z0-9\-_]+$", validationOptions);
+
     }
 
     /// <summary>

--- a/test/AgentTest.cs
+++ b/test/AgentTest.cs
@@ -113,6 +113,12 @@ TestIncrementPast", 13, pastEventTime));
     }
 
     [Test]
+    public void InvalidMetricNameReturnsNullUnicode()
+    {
+            Assert.AreEqual(null, agent.Increment("東京.怪獣", 13, pastEventTime));
+    }
+
+    [Test]
     public void TestNoticeAtATime()
     {
       agent.Notice("C# test notice FROM THE PAST using TimeSpan", pastEventTime, TimeSpan.FromMinutes(3));

--- a/test/AgentTest.cs
+++ b/test/AgentTest.cs
@@ -102,20 +102,26 @@ namespace Instrumental
     public void DisabledIncrementReturnsValue()
     {
       agent.Enabled = false;
-      Assert.AreEqual(13, agent.Increment("csharp.TestIncrementPast", 13, pastEventTime));
+      Assert.AreEqual(13, agent.Increment("csharp.TestIncrementPast", 13));
     }
 
     [Test]
     public void InvalidMetricNameReturnsNull()
     {
       Assert.AreEqual(null, agent.Increment(@"csharp.
-TestIncrementPast", 13, pastEventTime));
+TestIncrementPast", 13));
     }
 
     [Test]
     public void InvalidMetricNameReturnsNullUnicode()
     {
-            Assert.AreEqual(null, agent.Increment("東京.怪獣", 13, pastEventTime));
+            Assert.AreEqual(null, agent.Increment("東京.怪獣", 13));
+    }
+
+    [Test]
+    public void ValidMetricNamesCharacters()
+    {
+            Assert.AreEqual(13, agent.Increment("lower-UPPER_underscore.dots", 13));
     }
 
     [Test]


### PR DESCRIPTION
Fixes #18.

The behavior of java (and ruby) is to treat \d\w as the same as [a-zA-Z0-9], while C# allows unicode characters as well.

This version is fast, but makes the actual regular expression no longer match the rest of the ecosystem.  An alternative that preserves the regex but which is slightly (and I mean slightly!) slower is:

``` csharp
var validationOptions = RegexOptions.IgnoreCase | RegexOptions.ECMAScript;                               
var  _validateMetric = new Regex(@"^([\d\w\-_]+\.)*[\d\w\-_]+$", validationOptions); 
```

I prefer the faster, most explicit version, because even though it is different from the other agents, people who see the ECMAScript option and who are not hip deep in .NET regex will need to go look it up, whereas this version is pretty understandable without that extra context.
